### PR TITLE
CLOSES #1: copy don't share the config.

### DIFF
--- a/codemirror/widgets.py
+++ b/codemirror/widgets.py
@@ -16,7 +16,7 @@ class CodeMirror(forms.Textarea):
         }
 
     def __init__(self, **kwargs):
-        self.config = default_config
+        self.config = dict(default_config)
         self.config.update(kwargs)
         super(CodeMirror, self).__init__()
 


### PR DESCRIPTION
Up until now, each new widget instance would have refer _and mutate_
the original config from settings. This works fine if there is one and
only one kind of `CodeMirror` widget but as soon as there are widgets
with different config (e.g. an HTML widget and a JavaScript widget)
then hilarity ensues.

Simple solution: copy the config and update the copy.